### PR TITLE
Automatically choose net7/net8 SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 as build
+ARG DOTNET_VERSION=7.0
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} as build
 ARG CSHARPIER_VERSION=0.26.1
 
 RUN dotnet tool install --tool-path /tmp/tools csharpier --version ${CSHARPIER_VERSION}
 
-FROM mcr.microsoft.com/dotnet/runtime:7.0
+FROM mcr.microsoft.com/dotnet/runtime:${DOTNET_VERSION}
 
 # Metadata
 LABEL MAINTAINER=efrecon+github@gmail.com

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project implements:
 + A Docker [image] that runs any published version of [CSharpier].
 + An automated [workflow] to build and publish [images] when new versions of
   CSharpier are released.
-+ A [pre-commit] [hook] to run CSharpier on all staged files.
++ A [pre-commit] [hook] to run the latest CSharpier on all staged files.
 
   [image]: ./Dockerfile
   [CSharpier]: https://github.com/belav/csharpier
@@ -51,3 +51,31 @@ tree in a directory that you will have to ignore from version control.
 ```
 
   [history]: https://github.com/gpsgate/csharpier/commits/main
+
+## Version Capture
+
+The main Docker [image] is parameterised by a number of options/variables. These
+options will be set at build time from the [workflow] and its main [build]
+implementation script. The [build] script uses the GitHub API to fetch the list
+of known versions of [CSharpier] at the time of the run and will automatically
+build and push an image for each of them. In addition, the script generates a
+`latest` tag for the latest version of CSharpier. Finally, it is able to adapt
+to historical changes in the CSharpier dependencies (net7/net8 SDK).
+
+The [workflow] is set to run once a week, and will only build and push new
+images if either this project has changed or a new version of CSharpier has been
+released.
+
+  [build]: ./hooks/build+push
+
+## Development
+
+When developing this project, you can run and test its main [build] logic
+without using the GitHub Actions workflow. To do so, you can run the following
+command from the root of your tree. The command will perform all the steps
+described [above](#version-capture), only making the built images available to
+your local installation.
+
+```bash
+BUILDX_OPERATION=--load ./hooks/build+push
+```

--- a/hooks/build+push
+++ b/hooks/build+push
@@ -11,6 +11,7 @@ MINVER=${MINVER:-0.18.0}
 
 # You shouldn't really need to have to modify the following variables.
 GH_PROJECT=belav/csharpier
+BUILDX_OPERATION=${BUILDX_OPERATION:-"--push"};   # Change to --load to build only.
 
 # shellcheck disable=SC1091
 . "$(dirname "$0")/reg-tags/image_api.sh"
@@ -56,11 +57,18 @@ for tag in $(_releases "$GH_PROJECT"); do
         --platform "$PLATFORMS" \
         --build-arg CSHARPIER_VERSION="$tag" \
         --label "org.opencontainers.image.revision=$SOURCE_COMMIT" \
-        --push
+        $BUILDX_OPERATION
       # Add latest tag when relevant
       if [ "$tag" = "$_latest" ]; then
         set -- \
           --tag "${DOCKER_REPO}:latest" \
+          "$@"
+      fi
+      # Fix dotnet version, migrate to LTS 8.0 starting from 0.26.2. See:
+      # https://github.com/belav/csharpier/releases/tag/0.26.2
+      if [ "$(img_version "${tag#v}")" -ge "$(img_version "0.26.2")" ]; then
+        set -- \
+          --build-arg DOTNET_VERSION="8.0" \
           "$@"
       fi
       # build (and push) according to arguments and at the right tags.


### PR DESCRIPTION
Automatically choose the LTS net8 SDK starting from version 0.26.2 of CSharpier when building.