### PR TITLE
Skip build+push based on time instead

### DIFF
--- a/hooks/build+push
+++ b/hooks/build+push
@@ -30,6 +30,77 @@ _releases() {
     sed 's/_$//'
 }
 
+
+# Returns the number of seconds since the epoch for the ISO8601 date passed as
+# an argument. This will only recognise a subset of the standard, i.e. dates
+# with milliseconds, microseconds, nanoseconds or none specified, and timezone
+# only specified as diffs from UTC, e.g. 2019-09-09T08:40:39.505-07:00 or
+# 2019-09-09T08:40:39.505214+00:00. The special Z timezone (i.e. UTC) is also
+# recognised.
+_iso8601() {
+    # Arrange for tzdiff to be the number of seconds for the timezone.
+    tz=$(printf %s\\n "$1"|sed -E 's/([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(\.([0-9]{3,9}))?([+-]([0-9]{2}):([0-9]{2})|Z)?/\9/')
+    tzdiff=0
+    if [ -n "$tz" ]; then
+        if [ "$tz" = "Z" ]; then
+            tzdiff=0
+        else
+            hrs=$(printf %s\\n "$tz" | sed -E 's/[+-]([0-9]{2}):([0-9]{2})/\1/')
+            mns=$(printf %s\\n "$tz" | sed -E 's/[+-]([0-9]{2}):([0-9]{2})/\2/')
+            hrs=${hrs##0}; mns=${mns##0};   # Strip leading 0s
+            sign=$(printf %s\\n "$tz" | sed -E 's/([+-])([0-9]{2}):([0-9]{2})/\1/')
+            secs=$((hrs*3600+mns*60))
+            if [ "$sign" = "-" ]; then
+                tzdiff=$secs
+            else
+                tzdiff=$((-secs))
+            fi
+        fi
+    fi
+
+    # Extract UTC date and time into something that date can understand, then
+    # add the number of seconds representing the timezone.
+    utc=$(printf %s\\n "$1"|sed -E 's/([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(\.([0-9]{3,9}))?([+-]([0-9]{2}):([0-9]{2})|Z)?/\1-\2-\3 \4:\5:\6/')
+    if [ "$(uname -s)" = "Darwin" ]; then
+        secs=$(date -u -j -f "%Y-%m-%d %H:%M:%S" "$utc" +"%s")
+    else
+        secs=$(date -u -d "$utc" +"%s")
+    fi
+    # shellcheck disable=SC2003 # antiquated but we want parenthesis for clarity
+    expr "$secs" + \( "$tzdiff" \)
+}
+
+
+_docker_timestamp() {
+  # Remember if image was already present.
+  _present=0
+  if docker image inspect "$1" >/dev/null 2>&1; then
+    _present=1
+  fi
+
+  # Pull image in all cases, we want to have the latest known pushed image for
+  # that tag.
+  docker image pull --quiet "$1" || true
+
+  # Compute and print the timestamp of the image. 0 if the image does not exist.
+  _iso_date=$(docker image inspect --format '{{.Created}}' "$1")
+  if [ -z "$_iso_date" ]; then
+    printf %d\\n '0'
+  else
+    _iso8601 "$_iso_date"
+  fi
+
+  # Remove the image if it was not present before.
+  if ! $_present; then
+    docker image rm "$1" >/dev/null 2>&1
+  fi
+}
+
+
+# Return the UNIX timestamp of the commit reference(s) passed as argument.
+_git_timestamp() { git show -s --format="%ct" "$@";}
+
+
 echo "============== Gettings latest releases for $GH_PROJECT at github"
 _latest=
 for tag in $(_releases "$GH_PROJECT"); do
@@ -39,19 +110,10 @@ for tag in $(_releases "$GH_PROJECT"); do
   fi
 
   if [ "$(img_version "${tag#v}")" -ge "$(img_version "$MINVER")" ]; then
-    # Get the revision out of the org.opencontainers.image.revision label, this
-    # will be the label where we store information about this repo (it cannot be
-    # the tag, since we tag as the base image).
-    revision=$(img_labels --verbose --token "$token" -- "$DOCKER_REPO" "$tag" |
-                grep "^org.opencontainers.image.revision" |
-                sed -E 's/^org.opencontainers.image.revision=(.+)/\1/')
-    # If the revision is different from the source commit (including empty,
-    # which will happen when our version of the image does not already exist),
-    # build the image, making sure we label with the git commit sha at the
-    # org.opencontainers.image.revision OCI label, but using the same tag as the
-    # library image.
-    if [ "$revision" != "$SOURCE_COMMIT" ]; then
-      echo "============== No ${DOCKER_REPO}:$tag at $SOURCE_COMMIT"
+    img_date=$(_docker_timestamp "${DOCKER_REPO}:$tag")
+    git_date=$(_git_timestamp "$SOURCE_COMMIT")
+    if [ "$git_date" -ge "$img_date" ]; then
+      echo "============== Image ${DOCKER_REPO}:$tag older than $SOURCE_COMMIT"
       # Prepare arguments for docker buildx.
       set -- \
         --tag "${DOCKER_REPO}:$tag" \

--- a/hooks/build+push
+++ b/hooks/build+push
@@ -139,6 +139,8 @@ for tag in $(_releases "$GH_PROJECT"); do
       fi
       # build (and push) according to arguments and at the right tags.
       docker buildx build "$@" .
+    else
+      echo "!!!!!!!!!!!!!! Image ${DOCKER_REPO}:$tag newer than ${SOURCE_COMMIT}, skipping"
     fi
   fi
 done

--- a/hooks/build+push
+++ b/hooks/build+push
@@ -17,9 +17,6 @@ OCINS="org.opencontainers.image"
 # shellcheck disable=SC1091
 . "$(dirname "$0")/reg-tags/image_api.sh"
 
-# Login at the Docker hub to be able to access info about the image.
-token=$(img_auth "$DOCKER_REPO")
-
 _releases() {
   # Ask GH for the list of releases matching the tag pattern, then fool the sort
   # -V option to properly understand semantic versioning. Arrange for latest
@@ -71,6 +68,8 @@ _iso8601() {
 }
 
 
+# Return the UNIX timestamp of the docker image passed as argument. This
+# downloads the image in all cases.
 _docker_timestamp() {
   # Remember if image was already present.
   _present=0
@@ -80,7 +79,7 @@ _docker_timestamp() {
 
   # Pull image in all cases, we want to have the latest known pushed image for
   # that tag.
-  docker image pull --quiet "$1" || true
+  docker image pull --quiet "$1" >/dev/null || true
 
   # Compute and print the timestamp of the image. 0 if the image does not exist.
   _iso_date=$(docker image inspect --format '{{.Created}}' "$1")
@@ -91,7 +90,7 @@ _docker_timestamp() {
   fi
 
   # Remove the image if it was not present before.
-  if ! $_present; then
+  if [ "$_present" = "0" ]; then
     docker image rm "$1" >/dev/null 2>&1
   fi
 }


### PR DESCRIPTION
Manifests (for multi-platform images) are not entirely the same as images. As setting annotations on them (instead of labels) to detect necessary (re)builds is complex, this uses the time of the git commit vs. the time of the image build for the decision. Note that the test is not entirely exact, as what is returned is the time for when the image for the current platform was built (not the manifest), but this information is "good enough" as the build is only run from time to time.