### PR TITLE
dotnet tool first, fallback via docker

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,9 +8,5 @@
     - manual
   types:
     - c#
-  language: docker_image
-  entry: >-
-    -w /src
-    --rm
-    -t
-    ghcr.io/gpsgate/csharpier:latest
+  language: python
+  entry: csharpier

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ This project implements:
   versions of CSharpier are [released](#version-capture). Images are tagged with
   the version of [CSharpier]. The image tagged `latest` always points to the
   latest release of [CSharpier] at the time of the run.
-+ A [pre-commit] [hook] to run the `latest` CSharpier on all staged files.
++ A [pre-commit] [hook] to run [CSharpier] on the files passed to `pre-commit`.
+  The hook is a forgiving wrapper [implemented] in python: It will attempt to
+  run `csharpier` using `dotnet` first. If that fails, it will attempt to run it
+  using the `latest` Docker [image][images] built by this project.
 
   [image]: ./Dockerfile
   [CSharpier]: https://github.com/belav/csharpier
@@ -14,6 +17,7 @@ This project implements:
   [images]: https://github.com/gpsgate/csharpier/pkgs/container/csharpier
   [pre-commit]: https://pre-commit.com/
   [hook]: ./.pre-commit-hooks.yaml
+  [implemented]: ./pre_commit_hooks/csharpier.py
 
 ## Usage
 
@@ -42,7 +46,7 @@ docker run \
 Add the following to your `.pre-commit-config.yaml` file. You might want to
 check the latest version of the repository [here][history] and change the `rev`
 key. You might also want to remove the `--no-cache` argument, in which case
-CSharpier will store file-releted information in its cache at the root of your
+CSharpier will store file-related information in its cache at the root of your
 tree in a directory that you will have to ignore from version control.
 
 ```yaml

--- a/pre_commit_hooks/csharpier.py
+++ b/pre_commit_hooks/csharpier.py
@@ -125,7 +125,7 @@ def run_csharpier(options: Sequence[str]) -> bool:
   if not options:
     return False
   try:
-    out = cmd_output('dotnet', 'tool', 'run', 'dotnet-csharpier', '--', *options)
+    out = cmd_output('dotnet', 'csharpier', '--', *options)
     if out:
       print(out)
     return True

--- a/pre_commit_hooks/csharpier.py
+++ b/pre_commit_hooks/csharpier.py
@@ -139,12 +139,14 @@ def run_csharpier(options: Sequence[str]) -> bool:
   return False
 
 def main(argv: Sequence[str] | None = None) -> int:
-  parser = argparse.ArgumentParser()
-  parser.add_argument('remainder', nargs=argparse.REMAINDER)
+  parser = argparse.ArgumentParser(
+    description='Run csharpier, falls back to running it as a Docker container.'
+  )
+  parser.add_argument('options', nargs=argparse.REMAINDER)
   args = parser.parse_args(argv)
 
-  if not run_csharpier(args.remainder):
-    if not run_docker(args.remainder):
+  if not run_csharpier(args.options):
+    if not run_docker(args.options):
       return 1
   return 0
 

--- a/pre_commit_hooks/csharpier.py
+++ b/pre_commit_hooks/csharpier.py
@@ -42,7 +42,6 @@ class CalledProcessError(RuntimeError):
     return self.__bytes__().decode()
 
 def cmd_output(*cmd: str, retcode: int | None = 0, **kwargs: Any) -> str:
-  print(f'Running: {cmd}', file=sys.stderr)
   kwargs.setdefault('stdout', subprocess.PIPE)
   kwargs.setdefault('stderr', subprocess.PIPE)
   proc = subprocess.Popen(cmd, **kwargs)

--- a/pre_commit_hooks/csharpier.py
+++ b/pre_commit_hooks/csharpier.py
@@ -135,11 +135,10 @@ def run_csharpier(argv: Sequence[str] | None = None) -> bool:
     print('dotnet tool "csharpier" is not installed. Will run through Docker. You can also install it using "dotnet tool install -g dotnet-csharpier".', file=sys.stderr)
   return False
 
-def main(argv: Sequence[str] | None = None) -> int:
-  if not argv:
-    argv = ('--help')
-  if not run_csharpier(argv):
-    if not run_docker(argv):
+def main() -> int:
+  args = sys.argv[1:]
+  if not run_csharpier(args):
+    if not run_docker(args):
       return 1
   return 0
 

--- a/pre_commit_hooks/csharpier.py
+++ b/pre_commit_hooks/csharpier.py
@@ -42,6 +42,7 @@ class CalledProcessError(RuntimeError):
     return self.__bytes__().decode()
 
 def cmd_output(*cmd: str, retcode: int | None = 0, **kwargs: Any) -> str:
+  print(f'Running: {cmd}', file=sys.stderr)
   kwargs.setdefault('stdout', subprocess.PIPE)
   kwargs.setdefault('stderr', subprocess.PIPE)
   proc = subprocess.Popen(cmd, **kwargs)

--- a/pre_commit_hooks/csharpier.py
+++ b/pre_commit_hooks/csharpier.py
@@ -107,7 +107,7 @@ def run_docker(argv: Sequence[str] | None = None) -> bool:
                         '-v', f'{_get_docker_path(os.getcwd())}:/src:rw,Z',
                         '-w', '/src',
                         '-t',
-                        'ghcr.io/gpsgate/csharpier', '--', *argv)
+                        'ghcr.io/gpsgate/csharpier', *argv)
     if out:
       print(out)
     return True
@@ -122,7 +122,7 @@ def run_docker(argv: Sequence[str] | None = None) -> bool:
 
 def run_csharpier(argv: Sequence[str] | None = None) -> bool:
   try:
-    out = cmd_output('dotnet', 'csharpier', '--', *argv)
+    out = cmd_output('dotnet', 'csharpier', *argv)
     if out:
       print(out)
     return True

--- a/pre_commit_hooks/csharpier.py
+++ b/pre_commit_hooks/csharpier.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import json
+import sys
+from typing import Sequence
+
+class CalledProcessError(RuntimeError):
+  def __init__(
+          self,
+          cmd: tuple[str, ...],
+          expected_code: int,
+          return_code: int,
+          stdout: bytes,
+          stderr: bytes | None,
+  ) -> None:
+    super().__init__(cmd, expected_code, return_code, stdout, stderr)
+    self.cmd = cmd
+    self.expected_code = expected_code
+    self.return_code = return_code
+    self.stdout = stdout
+    self.stderr = stderr
+
+  def __bytes__(self) -> bytes:
+    def _indent_or_none(part: bytes | None) -> bytes:
+      if part:
+        return b'\n    ' + part.replace(b'\n', b'\n    ').rstrip()
+      else:
+        return b' (none)'
+
+    return b''.join((
+      f'command: {self.cmd!r}\n'.encode(),
+      f'expected code: {self.expected_code}\n'.encode(),
+      f'return code: {self.return_code}\n'.encode(),
+      b'stdout:', _indent_or_none(self.stdout), b'\n',
+      b'stderr:', _indent_or_none(self.stderr),
+    ))
+
+  def __str__(self) -> str:
+    return self.__bytes__().decode()
+
+def cmd_output(*cmd: str, retcode: int | None = 0, **kwargs: Any) -> str:
+  kwargs.setdefault('stdout', subprocess.PIPE)
+  kwargs.setdefault('stderr', subprocess.PIPE)
+  proc = subprocess.Popen(cmd, **kwargs)
+  stdout, stderr = proc.communicate()
+  stdout = stdout.decode()
+  if retcode is not None and proc.returncode != retcode:
+    raise CalledProcessError(cmd, retcode, proc.returncode, stdout, stderr)
+  return stdout
+
+def _get_container_id() -> str:
+  # It's assumed that we already check /proc/1/cgroup in _is_in_docker. The
+  # cpuset cgroup controller existed since cgroups were introduced so this
+  # way of getting the container ID is pretty reliable.
+  with open('/proc/1/cgroup', 'rb') as f:
+    for line in f.readlines():
+      if line.split(b':')[1] == b'cpuset':
+        return os.path.basename(line.split(b':')[2]).strip().decode()
+  raise RuntimeError('Failed to find the container ID in /proc/1/cgroup.')
+
+def _is_in_docker() -> bool:
+  try:
+    with open('/proc/1/cgroup', 'rb') as f:
+      return b'docker' in f.read()
+  except FileNotFoundError:
+    return False
+
+def _get_docker_path(path: str) -> str:
+  if not _is_in_docker():
+    return path
+
+  container_id = _get_container_id()
+
+  try:
+    out = cmd_output('docker', 'inspect', container_id)
+  except CalledProcessError:
+    # self-container was not visible from here (perhaps docker-in-docker)
+    return path
+
+  container, = json.loads(out)
+  for mount in container['Mounts']:
+    src_path = mount['Source']
+    to_path = mount['Destination']
+    if os.path.commonpath((path, to_path)) == to_path:
+      # So there is something in common,
+      # and we can proceed remapping it
+      return path.replace(to_path, src_path)
+  # we're in Docker, but the path is not mounted, cannot really do anything,
+  # so fall back to original path
+  return path
+
+def get_docker_user() -> tuple[str, ...]:  # pragma: win32 no cover
+  try:
+    return ('-u', f'{os.getuid()}:{os.getgid()}')
+  except AttributeError:
+    return ()
+
+def run_docker(options: Sequence[str]) -> bool:
+  if not options:
+    return False
+  try:
+    out = cmd_output('docker', 'run',
+                        '--rm',
+                        *get_docker_user(),
+                        '-v', f'{_get_docker_path(os.getcwd())}:/src:rw,Z',
+                        '-w', '/src',
+                        '-t',
+                        'ghcr.io/gpsgate/csharpier', *options)
+    if out:
+      print(out)
+    return True
+  except CalledProcessError as e:
+    if e.stderr:
+      print(e.stderr, file=sys.stderr)
+    if e.stdout:
+      print(e.stdout)
+  except FileNotFoundError:
+    print('docker is not installed. Ran out of options. Giving up!')
+  return False
+
+def run_csharpier(options: Sequence[str]) -> bool:
+  if not options:
+    return False
+  try:
+    out = cmd_output('dotnet', 'tool', 'run', 'dotnet-csharpier', '--', *options)
+    if out:
+      print(out)
+    return True
+  except CalledProcessError as e:
+    if e.stderr:
+      print(e.stderr, file=sys.stderr)
+    if e.stdout:
+      print(e.stdout)
+  except FileNotFoundError:
+    print('dotnet tool "csharpier" is not installed. Will run through Docker. You can also install it using "dotnet tool install -g dotnet-csharpier".')
+  return False
+
+def main(argv: Sequence[str] | None = None) -> int:
+  parser = argparse.ArgumentParser()
+  parser.add_argument('remainder', nargs=argparse.REMAINDER)
+  args = parser.parse_args(argv)
+
+  if not run_csharpier(args.remainder):
+    if not run_docker(args.remainder):
+      return 1
+  return 0
+
+if __name__ == '__main__':
+  raise SystemExit(main())

--- a/pre_commit_hooks/csharpier.py
+++ b/pre_commit_hooks/csharpier.py
@@ -125,7 +125,7 @@ def run_csharpier(options: Sequence[str]) -> bool:
   if not options:
     return False
   try:
-    out = cmd_output('dotnet', 'csharpier', '--', *options)
+    out = cmd_output('dotnet', 'csharpier', *options)
     if out:
       print(out)
     return True

--- a/pre_commit_hooks/csharpier.py
+++ b/pre_commit_hooks/csharpier.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import json
 import sys
-from typing import Sequence
+from typing import Any, Sequence
 
 class CalledProcessError(RuntimeError):
   def __init__(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,27 @@
+[metadata]
+name = csharpier
+version = 0.1.0
+description = Run CSharpier directly or through Docker.
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/gpsgate/csharpier
+author = Emmanuel Frecon
+author_email = efrecon+github@gmail.com
+license = MIT
+license_files = LICENSE
+classifiers =
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+
+[options]
+packages = find:
+python_requires = >=3.8
+
+[options.packages.find]
+exclude =
+    hooks*
+
+[options.entry_points]
+console_scripts =
+    csharpier = pre_commit_hooks.csharpier:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = csharpier
-version = 0.1.0
+version = 0.2.0
 description = Run CSharpier directly or through Docker.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
Re-implement the pre-commit hook as a python wrapper. The wrapper will attempt to run csharpier directly as a dotnet tool. If not found, the wrapper will run the `latest` Docker image built by this project. The code for running the Docker image is heavily inspired from the `docker_image` implementation in the main project.