### PR TITLE
Pinpoint version of ubuntu to last known working

### DIFF
--- a/.github/workflows/csharpier.yml
+++ b/.github/workflows/csharpier.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   csharpier:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       -
         name: Checkout

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   keepalive:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: keepalive
         uses: efrecon/gh-action-keepalive@main


### PR DESCRIPTION
This pinpoints the version of Ubuntu to use in the workflows in order to get more deterministic behaviour.